### PR TITLE
chore: pass vault address to services constructor

### DIFF
--- a/balancer-js/package.json
+++ b/balancer-js/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@disscorp/sdk",
-    "version": "0.1.19",
+    "version": "0.1.20",
     "description": "JavaScript SDK for interacting with the Balancer Protocol V2",
     "license": "GPL-3.0-only",
     "homepage": "https://github.com/balancer-labs/balancer-sdk/balancer-js#readme",

--- a/balancer-js/package.json
+++ b/balancer-js/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@disscorp/sdk",
-    "version": "0.1.18",
+    "version": "0.1.19",
     "description": "JavaScript SDK for interacting with the Balancer Protocol V2",
     "license": "GPL-3.0-only",
     "homepage": "https://github.com/balancer-labs/balancer-sdk/balancer-js#readme",

--- a/balancer-js/package.json
+++ b/balancer-js/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@disscorp/sdk",
-    "version": "0.1.17",
+    "version": "0.1.18",
     "description": "JavaScript SDK for interacting with the Balancer Protocol V2",
     "license": "GPL-3.0-only",
     "homepage": "https://github.com/balancer-labs/balancer-sdk/balancer-js#readme",

--- a/balancer-js/src/modules/pricing/pricing.module.ts
+++ b/balancer-js/src/modules/pricing/pricing.module.ts
@@ -8,6 +8,7 @@ import {
 } from '@balancer-labs/sor';
 import { BalancerError, BalancerErrorCode } from '@/balancerErrors';
 import { Pools } from '@/modules/pools/pools.module';
+import { getNetworkConfig } from '@/modules/sdk.helpers';
 
 export class Pricing {
     private readonly swaps: Swaps;
@@ -17,7 +18,10 @@ export class Pricing {
         if (swaps) {
             this.swaps = swaps;
         } else {
-            this.swaps = new Swaps(config);
+            this.swaps = new Swaps(
+                config,
+                getNetworkConfig(config).addresses.contracts.vault
+            );
         }
         this.pools = new Pools(config);
     }

--- a/balancer-js/src/modules/relayer/relayer.module.ts
+++ b/balancer-js/src/modules/relayer/relayer.module.ts
@@ -23,6 +23,7 @@ import { SubgraphPoolBase } from '@balancer-labs/sor';
 
 import relayerLibraryAbi from '@/lib/abi/VaultActions.json';
 import aaveWrappingAbi from '@/lib/abi/AaveWrapping.json';
+import { getNetworkConfig } from '@/modules/sdk.helpers';
 
 export * from './types';
 
@@ -35,7 +36,10 @@ export class Relayer {
         if (swapsOrConfig instanceof Swaps) {
             this.swaps = swapsOrConfig;
         } else {
-            this.swaps = new Swaps(swapsOrConfig);
+            this.swaps = new Swaps(
+                swapsOrConfig,
+                getNetworkConfig(swapsOrConfig).addresses.contracts.vault
+            );
         }
     }
 

--- a/balancer-js/src/modules/sdk.module.ts
+++ b/balancer-js/src/modules/sdk.module.ts
@@ -18,7 +18,10 @@ export class BalancerSDK {
         public subgraph = new Subgraph(config),
         public pools = new Pools(config)
     ) {
-        this.swaps = new Swaps(this.sor);
+        this.swaps = new Swaps(
+            this.sor,
+            getNetworkConfig(config).addresses.contracts.vault
+        );
         this.relayer = new Relayer(this.swaps);
         this.pricing = new Pricing(config, this.swaps);
     }

--- a/balancer-js/src/modules/sor/pool-data/onChainData.ts
+++ b/balancer-js/src/modules/sor/pool-data/onChainData.ts
@@ -44,6 +44,9 @@ export async function getOnChainBalances(
             console.error(`Unknown pool type: ${pool.poolType} ${pool.id}`);
             return;
         }
+        if (!pool.tokensList.length) {
+            return;
+        }
 
         subgraphPools.push(pool);
 

--- a/balancer-js/src/modules/sor/pool-data/onChainData.ts
+++ b/balancer-js/src/modules/sor/pool-data/onChainData.ts
@@ -44,9 +44,6 @@ export async function getOnChainBalances(
             console.error(`Unknown pool type: ${pool.poolType} ${pool.id}`);
             return;
         }
-        if (!pool.tokensList.length) {
-            return;
-        }
 
         subgraphPools.push(pool);
 

--- a/balancer-js/src/modules/sor/pool-data/subgraphPoolDataService.ts
+++ b/balancer-js/src/modules/sor/pool-data/subgraphPoolDataService.ts
@@ -67,7 +67,7 @@ export class SubgraphPoolDataService implements PoolDataService {
 
     private async getLinearPools() {
         const { pool0, pool1000 } = await this.client.Pools({
-            where: { swapEnabled: true },
+            where: { swapEnabled: true, tokensList_not: [] },
             orderBy: Pool_OrderBy.TotalLiquidity,
             orderDirection: OrderDirection.Desc,
         });
@@ -79,7 +79,7 @@ export class SubgraphPoolDataService implements PoolDataService {
 
     private async getNonLinearPools() {
         const { pools } = await this.client.PoolsWithoutLinear({
-            where: { swapEnabled: true },
+            where: { swapEnabled: true, tokensList_not: [] },
             orderBy: Pool_OrderBy.TotalLiquidity,
             orderDirection: OrderDirection.Desc,
             first: 1000,

--- a/balancer-js/src/modules/swaps/swaps.module.spec.ts
+++ b/balancer-js/src/modules/swaps/swaps.module.spec.ts
@@ -10,6 +10,7 @@ import {
 } from '@/.';
 import { mockPool, mockPoolDataService } from '@/test/lib/mockPool';
 import { SwapType } from './types';
+import { balancerVault } from '@/lib/constants/config';
 
 dotenv.config();
 
@@ -28,7 +29,7 @@ const sdkConfig: BalancerSdkConfig = {
 describe('swaps module', () => {
     context('instantiation', () => {
         it('instantiate via module', async () => {
-            const swaps = new Swaps(sdkConfig);
+            const swaps = new Swaps(sdkConfig, balancerVault);
             await swaps.fetchPools();
             const pools = swaps.getPools();
             expect(pools).to.deep.eq([mockPool]);

--- a/balancer-js/src/modules/swaps/swaps.module.ts
+++ b/balancer-js/src/modules/swaps/swaps.module.ts
@@ -14,7 +14,6 @@ import {
     queryBatchSwapWithSor,
     getSorSwapInfo,
 } from './queryBatchSwap';
-import { balancerVault } from '@/lib/constants/config';
 import { getLimitsForSlippage } from './helpers';
 import vaultAbi from '@/lib/abi/Vault.json';
 import { BalancerSdkConfig } from '@/types';
@@ -28,8 +27,10 @@ import { Interface } from '@ethersproject/abi';
 
 export class Swaps {
     readonly sor: SOR;
+    readonly vaultAddress: string;
 
-    constructor(sorOrConfig: SOR | BalancerSdkConfig) {
+    constructor(sorOrConfig: SOR | BalancerSdkConfig, vaultAddress: string) {
+        this.vaultAddress = vaultAddress;
         if (sorOrConfig instanceof SOR) {
             this.sor = sorOrConfig;
         } else {
@@ -140,7 +141,7 @@ export class Swaps {
     ): Promise<string[]> {
         // TO DO - Pull in a ContractsService and use this to pass Vault to queryBatchSwap.
         const vaultContract = new Contract(
-            balancerVault,
+            this.vaultAddress,
             vaultAbi,
             this.sor.provider
         );
@@ -168,7 +169,7 @@ export class Swaps {
     ): Promise<QueryWithSorOutput> {
         // TO DO - Pull in a ContractsService and use this to pass Vault to queryBatchSwap.
         const vaultContract = new Contract(
-            balancerVault,
+            this.vaultAddress,
             vaultAbi,
             this.sor.provider
         );
@@ -202,7 +203,7 @@ export class Swaps {
     ): Promise<QuerySimpleFlashSwapResponse> {
         // TO DO - Pull in a ContractsService and use this to pass Vault to queryBatchSwap.
         const vaultContract = new Contract(
-            balancerVault,
+            this.vaultAddress,
             vaultAbi,
             this.sor.provider
         );


### PR DESCRIPTION
* queryBatchSwap had vault address hardcoded to mainnet. Updated to receive the address considering which network is being used
* multicall was crashing due to empty token pools, this prevented us updating prices from onchain data. Added filter to avoid calling on empty pools